### PR TITLE
Add support for custom cell renderer and codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 addons:
   apt:

--- a/.travis/publish-coverage.sh
+++ b/.travis/publish-coverage.sh
@@ -6,4 +6,4 @@ then
   exit 0
 fi
 
-bash <(curl -s https://codecov.io/bash) -f coverage/coverage.json
+bash <(curl -s https://codecov.io/bash) -f coverage/coverage-final.json

--- a/.travis/publish-coverage.sh
+++ b/.travis/publish-coverage.sh
@@ -6,4 +6,4 @@ then
   exit 0
 fi
 
-cat coverage/lcov.info | coveralls
+bash <(curl -s https://codecov.io/bash) -f coverage/coverage.json

--- a/addon/components/frost-fixed-table.js
+++ b/addon/components/frost-fixed-table.js
@@ -168,8 +168,12 @@ export default Component.extend({
   _calculateWidth (cellSelector) {
     let width = 0
 
+    // It appears that there needs to be an additional 3 pixels for each cell in order for it to render correctly now
+    // I'm not actually sure why that might be, something to do with margins/border/padding of the cells perhaps?
+    const FUDGE_FACTOR = 3
+
     this.$(cellSelector).toArray().forEach((el) => {
-      width += $(el).outerWidth()
+      width += $(el).outerWidth() + FUDGE_FACTOR
     })
 
     return width

--- a/addon/components/frost-table-cell-renderer.js
+++ b/addon/components/frost-table-cell-renderer.js
@@ -1,26 +1,22 @@
 /**
- * Component definition for the frost-table-cell component
+ * Component definition for the frost-table-cell-renderer component
+ * This component can be used as a base-class for any cell renderer
  */
 
 import {Component} from 'ember-frost-core'
 import {PropTypes} from 'ember-prop-types'
-
-import layout from '../templates/components/frost-table-cell'
 
 export default Component.extend({
   // == Dependencies ==========================================================
 
   // == Keyword Properties ====================================================
 
-  layout,
-  tagName: 'td',
-
   // == PropTypes =============================================================
 
   propTypes: {
-    cellRenderer: PropTypes.any,
-    item: PropTypes.object,
-    value: PropTypes.any
+    // options
+    item: PropTypes.object.isRequired,
+    value: PropTypes.any.isRequired
   },
 
   // == Computed Properties ===================================================

--- a/addon/index.js
+++ b/addon/index.js
@@ -1,0 +1,11 @@
+/**
+ * Main export point for ember-frost-table addon
+ */
+
+export {default as FixedTable} from './components/frost-fixed-table'
+export {default as Body} from './components/frost-table-body'
+export {default as Cell} from './components/frost-table-cell'
+export {default as CellRenderer} from './components/frost-table-cell-renderer'
+export {default as Header} from './components/frost-table-header'
+export {default as Row} from './components/frost-table-row'
+export {default as Table} from './components/frost-table'

--- a/addon/templates/components/frost-table-cell.hbs
+++ b/addon/templates/components/frost-table-cell.hbs
@@ -1,0 +1,11 @@
+{{! Template for the frost-table-cell component }}
+{{#if cellRenderer}}
+  {{component cellRenderer
+    hook=(concat hookPrefix '-renderer')
+    hookQualifiers=hookQualifiers
+    item=item
+    value=value
+  }}
+{{else}}
+  {{value}}
+{{/if}}

--- a/addon/templates/components/frost-table-header.hbs
+++ b/addon/templates/components/frost-table-header.hbs
@@ -1,11 +1,11 @@
 {{! Template for the frost-table-header component }}
 {{#each columns as |column index|}}
-  {{#frost-table-cell
-    tagName=cellTagName
+  {{frost-table-cell
+    cellRenderer=column.headerRenderer
     class=(concat cellCss '-cell' ' ' column.className)
     hook=(concat hookPrefix '-cell')
     hookQualifiers=(extend hookQualifiers column=index)
+    tagName=cellTagName
+    value=column.label
   }}
-    {{~ column.label ~}}
-  {{/frost-table-cell}}
 {{/each}}

--- a/addon/templates/components/frost-table-row.hbs
+++ b/addon/templates/components/frost-table-row.hbs
@@ -1,11 +1,12 @@
 {{! Template for the frost-table-row component }}
 {{#each columns as |column index|}}
-  {{#frost-table-cell
-    tagName=cellTagName
+  {{frost-table-cell
+    cellRenderer=column.renderer
     class=(concat cellCss '-cell' ' ' column.className)
     hook=(concat hookPrefix '-cell')
     hookQualifiers=(extend hookQualifiers column=index)
+    item=item
+    tagName=cellTagName
+    value=(get item column.propertyName)
   }}
-    {{~ get item column.propertyName ~}}
-  {{/frost-table-cell}}
 {{/each}}

--- a/addon/typedefs.js
+++ b/addon/typedefs.js
@@ -7,6 +7,7 @@ import {PropTypes} from 'ember-prop-types'
 /**
  * @typedef Column
  * @property {String} [className] - the name of the class to add to all cells of a column
+ * @property {Component} [headerRenderer] - the cell renderer to use for the header of this column
  * @property {String} label - the column header label
  * @property {String} propertyName - the name of the property in the data record to display in this column
  * @property {Boolean} [frozen=false] - true if this column should be frozen (on either the left or right side of the table)
@@ -16,6 +17,7 @@ import {PropTypes} from 'ember-prop-types'
 export const ColumnPropType = PropTypes.shape({
   className: PropTypes.string,
   frozen: PropTypes.bool,
+  headerRenderer: PropTypes.any,
   label: PropTypes.string,
   propertyName: PropTypes.string.isRequired,
   renderer: PropTypes.any

--- a/app/components/frost-table-cell-renderer.js
+++ b/app/components/frost-table-cell-renderer.js
@@ -1,0 +1,4 @@
+/**
+ * Simple re-export of frost-table-cell-renderer in the app namespace
+ */
+export {default} from 'ember-frost-table/components/frost-table-cell-renderer'

--- a/config/coverage.js
+++ b/config/coverage.js
@@ -2,6 +2,7 @@ module.exports = {
   coverageEnvVar: 'COVERAGE',
   coverageFolder: 'coverage',
   useBabelInstrumenter: true,
+  reporters: ['json'],
   excludes: [
     '*/app/**/*',
     '*/tests/**/*'

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "ci-test": "ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test",
     "test": "npm run lint && COVERAGE=true ember test",
     "eslint": "eslint *.js addon app blueprints config tests",
-    "md-lint": "find . -name '*.md' -depth 1 |  grep -v CHANGELOG | xargs remark",
+    "md-lint": "find . -depth 1 -name '*.md' | grep -v CHANGELOG | xargs remark",
     "sass-lint": "sass-lint -q -v",
     "lint": "npm run eslint && npm run sass-lint && npm run md-lint"
   },

--- a/testem.js
+++ b/testem.js
@@ -1,11 +1,15 @@
+const Reporter = require('ember-test-utils/reporter')
+
 module.exports = {
   'framework': 'mocha',
   'test_page': 'tests/index.html?hidepassed',
   'disable_watching': true,
   'launch_in_ci': [
+    'Chrome',
     'Firefox'
   ],
   'launch_in_dev': [
     'Chrome'
-  ]
+  ],
+  reporter: new Reporter()
 }

--- a/tests/dummy/app/pods/components/text-input-renderer/component.js
+++ b/tests/dummy/app/pods/components/text-input-renderer/component.js
@@ -1,27 +1,19 @@
 /**
- * Component definition for the frost-table-cell component
+ * Component definition for the text-input-renderer component
  */
 
-import {Component} from 'ember-frost-core'
-import {PropTypes} from 'ember-prop-types'
+import {CellRenderer} from 'ember-frost-table'
 
-import layout from '../templates/components/frost-table-cell'
+import layout from './template'
 
-export default Component.extend({
+export default CellRenderer.extend({
   // == Dependencies ==========================================================
 
   // == Keyword Properties ====================================================
 
   layout,
-  tagName: 'td',
 
   // == PropTypes =============================================================
-
-  propTypes: {
-    cellRenderer: PropTypes.any,
-    item: PropTypes.object,
-    value: PropTypes.any
-  },
 
   // == Computed Properties ===================================================
 

--- a/tests/dummy/app/pods/components/text-input-renderer/template.hbs
+++ b/tests/dummy/app/pods/components/text-input-renderer/template.hbs
@@ -1,0 +1,7 @@
+{{! Template for the text-input-renderer component }}
+{{frost-text
+  hook=(concat hookPrefix '-text')
+  hookPrefix=hook
+  hookQualifiers=hookQualifiers
+  value=value
+}}

--- a/tests/dummy/app/pods/demo/frost-fixed-table/template.hbs
+++ b/tests/dummy/app/pods/demo/frost-fixed-table/template.hbs
@@ -4,8 +4,10 @@
     columns=(array
       (hash
         className= // e.g. 'name-column'
+        headerRenderer= // a component to render the header for this column
         label= // e.g. 'Name'
         propertyName= // e.g. 'name'
+        renderer= // a component to render the data cells for this column
       )
     )
     hook= // e.g. 'myTable'
@@ -42,6 +44,7 @@
       columns=(array
         (hash
           className='name-col'
+          headerRenderer=(component 'text-input-renderer')
           frozen=true
           label='Name'
           propertyName='name'
@@ -55,11 +58,7 @@
           className='real-name-col'
           label='Real Name'
           propertyName='realName'
-        )
-        (hash
-          className='real-name-col'
-          label='Real Name'
-          propertyName='realName'
+          renderer=(component 'text-input-renderer')
         )
         (hash
           className='real-name-col'

--- a/tests/dummy/app/pods/demo/frost-table/template.hbs
+++ b/tests/dummy/app/pods/demo/frost-table/template.hbs
@@ -4,8 +4,10 @@
     columns=(array
       (hash
         className= // e.g. 'name-column'
+        headerRenderer= // a component to render the header for this column
         label= // e.g. 'Name'
         propertyName= // e.g. 'name'
+        renderer= // a component to render the data cells for this column
       )
     )
     hook= // e.g. 'myTable'
@@ -41,12 +43,14 @@
     {{frost-table
       columns=(array
         (hash
+          headerRenderer=(component 'text-input-renderer')
           label='Name'
           propertyName='name'
         )
         (hash
           label='Real Name'
           propertyName='realName'
+          renderer=(component 'text-input-renderer')
         )
         (hash
           label='Universe'

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -168,14 +168,24 @@ dl {
 .frost-fixed-table {
   max-width: 500px;
   max-height: 500px;
+
+  .name-col {
+    &.frost-table-header-cell {
+      padding: 0;
+    }
+  }
+
+  .frost-table-cell {
+    height: 55px;
+  }
 }
 
 .name-col {
-  width: 100px;
+  width: 200px;
 }
 
 .real-name-col {
-  width: 175px;
+  width: 250px;
 }
 
 .universe-col {

--- a/tests/integration/components/frost-table-body-test.js
+++ b/tests/integration/components/frost-table-body-test.js
@@ -43,7 +43,7 @@ describe(test.label, function () {
     })
 
     it('should display proper cell data', function () {
-      const cellData = $hook('myTableBody-row-cell').toArray().map((el) => $(el).text())
+      const cellData = $hook('myTableBody-row-cell').toArray().map((el) => $(el).text().trim())
 
       const expected = []
       heroes.forEach((hero) => {

--- a/tests/integration/components/frost-table-cell-renderer-test.js
+++ b/tests/integration/components/frost-table-cell-renderer-test.js
@@ -1,0 +1,41 @@
+/**
+ * Integration test for the frost-table-cell-renderer component
+ * This is basically an abstract base class, so not much to test here
+ */
+
+import {expect} from 'chai'
+import hbs from 'htmlbars-inline-precompile'
+import {$hook} from 'ember-hook'
+import wait from 'ember-test-helpers/wait'
+import {beforeEach, describe, it} from 'mocha'
+
+import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
+
+const test = integration('frost-table-cell-renderer')
+describe(test.label, function () {
+  test.setup()
+
+  describe('after render', function () {
+    beforeEach(function () {
+      this.setProperties({
+        myHook: 'myThing'
+      })
+
+      this.render(hbs`
+        {{frost-table-cell-renderer
+          hook=myHook
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should have an element', function () {
+      expect(this.$()).to.have.length(1)
+    })
+
+    it('should be accessible via the hook', function () {
+      expect($hook('myThing')).to.have.length(1)
+    })
+  })
+})

--- a/tests/integration/components/frost-table-cell-test.js
+++ b/tests/integration/components/frost-table-cell-test.js
@@ -19,38 +19,64 @@ describe(test.label, function () {
 
   beforeEach(function () {
     sandbox = sinon.sandbox.create()
+    this.setProperties({
+      myHook: 'myThing',
+      value: 'my value'
+    })
   })
 
   afterEach(function () {
     sandbox.restore()
   })
 
-  // FIXME: actually add real tests in next PR when frost-table-cell supports custom renderer components
-  it.skip('should have real tests', function () {
-    expect(true).to.equal(false)
-  })
-
-  describe('after render', function () {
+  describe('after render with value', function () {
     beforeEach(function () {
-      this.setProperties({
-        myHook: 'myThing'
-      })
-
       this.render(hbs`
         {{frost-table-cell
           hook=myHook
+          value=value
         }}
       `)
 
       return wait()
     })
 
-    it('should have an element', function () {
-      expect(this.$()).to.have.length(1)
+    it('should have an element with the proper className', function () {
+      expect(this.$('.frost-table-cell')).to.have.length(1)
     })
 
     it('should be accessible via the hook', function () {
       expect($hook('myThing')).to.have.length(1)
+    })
+
+    it('should render the given value', function () {
+      expect($hook('myThing').text().trim()).to.equal('my value')
+    })
+  })
+
+  describe('after render with custom renderer', function () {
+    beforeEach(function () {
+      this.render(hbs`
+        {{frost-table-cell
+          cellRenderer=(component 'text-input-renderer')
+          hook=myHook
+          value=value
+        }}
+      `)
+
+      return wait()
+    })
+
+    it('should have an element with the proper className wrapping the custom renderer', function () {
+      expect(this.$('.frost-table-cell .text-input-renderer')).to.have.length(1)
+    })
+
+    it('should be accessible via the hook', function () {
+      expect($hook('myThing')).to.have.length(1)
+    })
+
+    it('should render the given value', function () {
+      expect($hook('myThing-renderer-text-input').val()).to.equal('my value')
     })
   })
 })

--- a/tests/integration/components/frost-table-header-test.js
+++ b/tests/integration/components/frost-table-header-test.js
@@ -36,9 +36,66 @@ describe(test.label, function () {
       return wait()
     })
 
+    it('should have a frost-table-cell per column', function () {
+      expect(this.$('.frost-table-cell')).to.have.length(columns.length)
+    })
+
     it('should display proper column labels', function () {
-      const columnNames = $hook('myTableHeader-cell').toArray().map((el) => $(el).text())
+      const columnNames = $hook('myTableHeader-cell').toArray().map((el) => $(el).text().trim())
       expect(columnNames).to.eql(columns.map((col) => col.label))
+    })
+
+    describe('when columns updated to have custom cell renderers', function () {
+      beforeEach(function () {
+        const newColumns = [
+          {
+            className: 'name-col',
+            label: 'Name',
+            renderer: 'text-input-renderer',
+            propertyName: 'name'
+          },
+          {
+            className: 'real-name-col',
+            label: 'Real Name',
+            renderer: 'text-input-renderer',
+            propertyName: 'realName'
+          }
+        ]
+
+        this.set('columns', newColumns)
+
+        return wait()
+      })
+
+      it('should not have any text-input-renderer components', function () {
+        expect(this.$('.text-input-renderer')).to.have.length(0)
+      })
+    })
+
+    describe('when one column updated to have custom header renderer', function () {
+      beforeEach(function () {
+        const newColumns = [
+          {
+            className: 'name-col',
+            headerRenderer: 'text-input-renderer',
+            label: 'Name',
+            propertyName: 'name'
+          },
+          {
+            className: 'real-name-col',
+            label: 'Real Name',
+            propertyName: 'realName'
+          }
+        ]
+
+        this.set('columns', newColumns)
+
+        return wait()
+      })
+
+      it('should have one text-input-renderer components', function () {
+        expect(this.$('.text-input-renderer')).to.have.length(1)
+      })
     })
   })
 })

--- a/tests/integration/components/frost-table-row-test.js
+++ b/tests/integration/components/frost-table-row-test.js
@@ -13,7 +13,7 @@ import {beforeEach, describe, it} from 'mocha'
 import {integration} from 'dummy/tests/helpers/ember-test-utils/setup-component-test'
 import {columns, heroes} from './data'
 
-const test = integration('frost-table-body-row')
+const test = integration('frost-table-row')
 describe(test.label, function () {
   test.setup()
 
@@ -38,8 +38,12 @@ describe(test.label, function () {
       return wait()
     })
 
+    it('should have a frost-table-cell per column', function () {
+      expect(this.$('.frost-table-cell')).to.have.length(columns.length)
+    })
+
     it('should display proper cell data', function () {
-      const cellData = $hook('myTableRow-cell').toArray().map((el) => $(el).text())
+      const cellData = $hook('myTableRow-cell').toArray().map((el) => $(el).text().trim())
 
       const expected = []
       columns.forEach((col) => {
@@ -47,6 +51,59 @@ describe(test.label, function () {
       })
 
       expect(cellData).to.eql(expected)
+    })
+
+    describe('when columns updated to have custom header renderers', function () {
+      beforeEach(function () {
+        const newColumns = [
+          {
+            className: 'name-col',
+            headerRenderer: 'text-input-renderer',
+            label: 'Name',
+            propertyName: 'name'
+          },
+          {
+            className: 'real-name-col',
+            headerRenderer: 'text-input-renderer',
+            label: 'Real Name',
+            propertyName: 'realName'
+          }
+        ]
+
+        this.set('columns', newColumns)
+
+        return wait()
+      })
+
+      it('should not have any text-input-renderer components', function () {
+        expect(this.$('.text-input-renderer')).to.have.length(0)
+      })
+    })
+
+    describe('when one column updated to have custom cell renderer', function () {
+      beforeEach(function () {
+        const newColumns = [
+          {
+            className: 'name-col',
+            label: 'Name',
+            propertyName: 'name',
+            renderer: 'text-input-renderer'
+          },
+          {
+            className: 'real-name-col',
+            label: 'Real Name',
+            propertyName: 'realName'
+          }
+        ]
+
+        this.set('columns', newColumns)
+
+        return wait()
+      })
+
+      it('should have one text-input-renderer components', function () {
+        expect(this.$('.text-input-renderer')).to.have.length(1)
+      })
     })
   })
 })

--- a/tests/integration/components/frost-table-test.js
+++ b/tests/integration/components/frost-table-test.js
@@ -47,7 +47,7 @@ describe(test.label, function () {
     })
 
     it('should give the header the set of columns', function () {
-      const columnNames = $hook('myTable-header-cell').toArray().map((el) => $(el).text())
+      const columnNames = $hook('myTable-header-cell').toArray().map((el) => $(el).text().trim())
       expect(columnNames).to.eql(columns.map((col) => col.label))
     })
 
@@ -57,7 +57,7 @@ describe(test.label, function () {
 
     it('should be able to grab a cell via a hook', function () {
       const expected = get(heroes[1], columns[1].propertyName)
-      expect($hook('myTable-body-row-cell', {row: 1, column: 1})).to.have.text(expected)
+      expect($hook('myTable-body-row-cell', {row: 1, column: 1}).text().trim()).to.equal(expected)
     })
   })
 })

--- a/tests/unit/index-test.js
+++ b/tests/unit/index-test.js
@@ -1,0 +1,25 @@
+/**
+ * Unit test for the main export point of ember-frost-table
+ */
+
+import {expect} from 'chai'
+import {describe, it} from 'mocha'
+import * as tableExports from 'ember-frost-table'
+
+describe('index', function () {
+  const components = [
+    'FixedTable',
+    'Body',
+    'Cell',
+    'CellRenderer',
+    'Header',
+    'Row',
+    'Table'
+  ]
+
+  components.forEach((component) => {
+    it(`should include the ${component} component`, function () {
+      expect(tableExports[component]).not.to.equal(undefined)
+    })
+  })
+})


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [ ] #patch# - backwards-compatible bug fix
 - [x] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

# CHANGELOG
* **Added** support for custom renderers for cells
* **Added** codecov.io integration
