### PR TITLE
Update to new linting functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
 - ./node_modules/.bin/bower install
 script:
 - npm run lint
-- npm run ci-test
+- npm run test
 after_success:
 - .travis/publish-coverage.sh
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ deploy:
     branch: master
     condition: "$EMBER_TRY_SCENARIO = 'default'"
     node: 'stable'
-    tags: false
+    tags: true
 after_deploy:
 - .travis/publish-gh-pages.sh
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,20 @@
 # 1.0.1
-* **Fixed** issue with namespace of exported `.scss` files. We were putting all the `_foo.scss` files directly into `app/styles` instead of `app/styles/ember-frost-table` polluting the top-level styles directory for the consuming app. That wasn't very nice of us. We don't do that anymore. 
+* **Fixed** issue with namespace of exported `.scss` files. We were putting all the `_foo.scss` files directly into
+`app/styles` instead of `app/styles/ember-frost-table` polluting the top-level styles directory for the consuming app.
+That wasn't very nice of us. We don't do that anymore.
 
 
 # 1.0.0
-- `frost-fixed-table` and `frost-table` can now handle custom callback propagation from individual cells in the header or body sections.
-- Custom table cell renders are now given an `onCallback(action, args)` method that they can call to propagate events or any other notification that needs to escape the table.
-- Passing an `onCallback({action, args, col, row})` to the table will allow the consumer of the table to receive these events.
+- `frost-fixed-table` and `frost-table` can now handle custom callback propagation from individual cells in the header
+or body sections.
+- Custom table cell renders are now given an `onCallback(action, args)` method that they can call to propagate events
+or any other notification that needs to escape the table.
+- Passing an `onCallback({action, args, col, row})` to the table will allow the consumer of the table to receive
+these events.
 - Linting warnings have been fixed, and warnings from `ocd/sort-import-declarations` are now reported as errors.
-- **Breaking change**: Columns in `frost-fixed-table` sections now have globally unique column indices in their ember hooks, rather than having each of the left/middle/right sections index from zero, so that the generic event callback can uniquely identify table cells more easily
+- **Breaking change**: Columns in `frost-fixed-table` sections now have globally unique column indices in their ember
+hooks, rather than having each of the left/middle/right sections index from zero, so that the generic event callback
+can uniquely identify table cells more easily
 - **Breaking change**: `items` and `columns` arguments are now required.
 
 
@@ -21,9 +28,10 @@
 
 
 # 0.2.0
- * **Added** `frost-fixed-table` component which allows for frozen left and right columns and a fixed header row, but relies on fixed column widths/heights to work properly. 
+ * **Added** `frost-fixed-table` component which allows for frozen left and right columns and a fixed header row,
+but relies on fixed column widths/heights to work properly.
 * **Updated** `ember-frost-core`
-* **Updated** existing components to derive from `frost-component` now. 
+* **Updated** existing components to derive from `frost-component` now.
 
 
 # 0.1.0

--- a/package.json
+++ b/package.json
@@ -8,13 +8,9 @@
   },
   "scripts": {
     "build": "ember build",
+    "lint": "lint-all-the-things",
     "start": "ember server",
-    "ci-test": "ember try:one $EMBER_TRY_SCENARIO --- COVERAGE=true ember test",
-    "test": "npm run lint && COVERAGE=true ember test",
-    "eslint": "eslint *.js addon app blueprints config tests",
-    "md-lint": "find . -depth 1 -name '*.md' | grep -v CHANGELOG | xargs remark",
-    "sass-lint": "sass-lint -q -v",
-    "lint": "npm run eslint && npm run sass-lint && npm run md-lint"
+    "test": "npm run lint && COVERAGE=true ember test"
   },
   "repository": "git@github.com:ciena-frost/ember-frost-table.git",
   "engines": {
@@ -53,15 +49,10 @@
     "ember-resolver": "^2.0.3",
     "ember-sinon": "^0.5.1",
     "ember-spread": "^1.0.0",
-    "ember-test-utils": "^1.5.0",
+    "ember-test-utils": "^1.10.7",
     "ember-truth-helpers": "^1.3.0",
-    "eslint": "^3.4.0",
-    "eslint-config-frost-standard": "^5.0.0",
     "loader.js": "^4.0.10",
-    "lodash-es": "4.15.0",
-    "remark-cli": "^2.1.0",
-    "remark-lint": "^5.2.0",
-    "sass-lint": "^1.10.2"
+    "lodash-es": "4.15.0"
   },
   "dependencies": {
     "ember-cli-babel": "^5.1.6",

--- a/tests/dummy/app/styles/app.scss
+++ b/tests/dummy/app/styles/app.scss
@@ -156,7 +156,7 @@ dl {
 }
 
 .frost-table-demo {
-  padding: 10px ;
+  padding: 10px;
 }
 
 .frost-fixed-table-api {


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:
 - [X] #patch# - backwards-compatible bug fix
 - [ ] #minor# - adding functionality in a backwards-compatible manner
 - [ ] #major# - incompatible API change

Closes: https://github.com/ciena-frost/ember-frost-table/issues/7

# CHANGELOG
* **Updated** Travis to only publish when git tags are added in preparation for non-version bump pull requests.
* **Updated** linting to use linting tools from `ember-test-utils`.