### PR TITLE
Fix demo and css for selection

### DIFF
--- a/addon/components/frost-table.js
+++ b/addon/components/frost-table.js
@@ -90,24 +90,31 @@ export default Component.extend({
       this.set('_isShiftDown', event.shiftKey)
     }
   },
+  setCellWidths (position) {
+    const curBodyColumn = this.$().find('.frost-table-row .frost-table-body-cell:nth-child(' + (position) + ')')
+    const curHeaderCell = this.$().find('.frost-table-header-cell:nth-child(' + (position) + ')')
 
+    const bodyCellWidth = curBodyColumn.outerWidth(true)
+    const headerCellWidth = curHeaderCell.outerWidth(true)
+
+    const width = bodyCellWidth > headerCellWidth ? bodyCellWidth : headerCellWidth
+
+    curHeaderCell.css('width', width + 'px')
+    curBodyColumn.css('width', width + 'px')
+  },
   // == DOM Events ============================================================
 
   // == Lifecycle Hooks =======================================================
 
   didInsertElement () {
     run.schedule('afterRender', this, function () {
+      const selectable = this.get('_isSelectable')
+      if (selectable) {
+        this.setCellWidths(1)
+      }
       this.columns.forEach((column, index) => {
-        const curBodyColumn = this.$().find('.frost-table-row .frost-table-body-cell:nth-child(' + (index + 1) + ')')
-        const curHeaderCell = this.$().find('.frost-table-header-cell:nth-child(' + (index + 1) + ')')
-
-        const bodyCellWidth = curBodyColumn.outerWidth(true)
-        const headerCellWidth = curHeaderCell.outerWidth(true)
-
-        const width = bodyCellWidth > headerCellWidth ? bodyCellWidth : headerCellWidth
-
-        curHeaderCell.css('width', width + 'px')
-        curBodyColumn.css('width', width + 'px')
+        let position = index + (selectable ? 2 : 1)
+        this.setCellWidths(position)
       })
     })
   },

--- a/addon/templates/components/frost-table-header.hbs
+++ b/addon/templates/components/frost-table-header.hbs
@@ -1,13 +1,13 @@
 {{! Template for the frost-table-header component }}
 {{#if isSelectable}}
-  <td class='frost-table-cell'>
+  <th class='frost-table-header-cell frost-table-cell'>
     {{frost-table-header-selection
       hook=(concat hookPrefix '-selectionCell')
       hookQualifiers=(extend hookQualifiers column=column.index)
 
       onSelectionChange=onSelectionChange
     }}
-  </td>
+  </th>
 {{/if}}
 {{#each columns as |column|}}
   {{frost-table-cell

--- a/addon/templates/components/frost-table-row.hbs
+++ b/addon/templates/components/frost-table-row.hbs
@@ -1,6 +1,6 @@
 {{! Template for the frost-table-row component }}
 {{#if isSelectable}}
-  <td class='frost-table-cell'>
+  <td class='frost-table-cell frost-table-body-cell'>
     {{frost-table-row-selection
       hook=(concat hookPrefix '-selectionCell')
       hookQualifiers=(extend hookQualifiers column=column.index)

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -44,6 +44,10 @@ module.exports = function (environment) {
   if (environment === 'production') {
     ENV.locationType = 'hash'
     ENV.rootURL = '/ember-frost-table'
+    ENV.mirageNamespace = 'https://ciena-frost.github.io'
+    ENV['ember-cli-mirage'] = {
+      enabled: true
+    }
   }
 
   return ENV

--- a/tests/dummy/mirage/config.js
+++ b/tests/dummy/mirage/config.js
@@ -1,3 +1,8 @@
+import config from '../config/environment'
+
 export default function () {
+  if (config && config.mirageNamespace) {
+    this.namespace = config.mirageNamespace
+  }
   this.get('/characters')
 }


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [x] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

Selection:
<img width="636" alt="screen shot 2017-06-09 at 1 32 36 pm" src="https://user-images.githubusercontent.com/9057680/26987106-448ff006-4d18-11e7-80a1-2c4d61ebddb1.png">

Regular table (to ensure no regressions):
<img width="631" alt="screen shot 2017-06-09 at 1 33 02 pm" src="https://user-images.githubusercontent.com/9057680/26987119-53e4e9d0-4d18-11e7-84eb-6331c5fbd974.png">

# CHANGELOG
 * Fix mirage for Demo page
* Fix CSS for Table Selection. Fixes https://github.com/ciena-frost/ember-frost-table/issues/20

