### PR TITLE
Fix frost-table demo

### DIFF
--- a/tests/dummy/app/pods/demo/frost-table/route.js
+++ b/tests/dummy/app/pods/demo/frost-table/route.js
@@ -1,3 +1,0 @@
-import HeroesRoute from '../heroes-route'
-
-export default HeroesRoute.extend({})

--- a/tests/dummy/app/pods/demo/frost-table/template.hbs
+++ b/tests/dummy/app/pods/demo/frost-table/template.hbs
@@ -63,7 +63,7 @@
         )
       )
       hook='myTable'
-      items=model.characters
+      items=heroes
 
       onCallback=(action 'dispatchNotification')
     }}


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This PR fixes issue #22 allowing the user to navigate to the `frost-table` demo

# CHANGELOG
 * **Fixed** issue #22
