### PR TITLE
Make selection behaviour match ember-frost-list

### DIFF
--- a/addon/components/frost-fixed-table.js
+++ b/addon/components/frost-fixed-table.js
@@ -472,8 +472,10 @@ export default Component.extend({
       this.onCallback({action, args, col, row})
     },
 
-    _clickRow (row) {
-      this.$(`${this.get('_bodyLeftSelector')} .frost-table-row`).eq(row).trigger('click')
+    _clickRow (row, event) {
+      const leftSectionRow = this.$(`${this.get('_bodyLeftSelector')} .frost-table-row`).eq(row)
+      event.target = leftSectionRow[0]
+      leftSectionRow.trigger(event)
     },
 
     _select ({isRangeSelect, isSpecificSelect, item}) {

--- a/addon/components/frost-fixed-table.js
+++ b/addon/components/frost-fixed-table.js
@@ -16,6 +16,7 @@ export default Component.extend({
 
   // == Keyword Properties ====================================================
 
+  classNameBindings: ['_isShiftDown:shift-down'],
   layout,
 
   // == PropTypes =============================================================
@@ -32,6 +33,7 @@ export default Component.extend({
     onSelectionChange: PropTypes.func,
 
     // state
+    _isShiftDown: PropTypes.bool,
     _itemComparator: PropTypes.func,
 
     _rangeState: PropTypes.shape({
@@ -421,9 +423,25 @@ export default Component.extend({
     }
   },
 
+  setShift (event) {
+    if (!this.isDestroyed) {
+      this.set('_isShiftDown', event.shiftKey)
+    }
+  },
+
   // == DOM Events ============================================================
 
   // == Lifecycle Hooks =======================================================
+
+  init () {
+    this._super(...arguments)
+    this._keyHandler = this.setShift.bind(this)
+    $(document).on(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
+  },
+
+  willDestroy () {
+    $(document).off(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
+  },
 
   /**
    * Set up synced scrolling as well as calculating padding for middle sections

--- a/addon/components/frost-table-row.js
+++ b/addon/components/frost-table-row.js
@@ -3,14 +3,14 @@
  */
 
 import Ember from 'ember'
-const {isEmpty} = Ember
+const {ViewUtils, isEmpty} = Ember
+const {isSimpleClick} = ViewUtils
 import computed, {readOnly} from 'ember-computed-decorators'
 import {Component} from 'ember-frost-core'
 import {ColumnPropType, ItemPropType} from 'ember-frost-table/typedefs'
 import {PropTypes} from 'ember-prop-types'
 
 import layout from '../templates/components/frost-table-row'
-import {click} from '../utils/selection'
 
 export default Component.extend({
   // == Dependencies ==========================================================
@@ -64,7 +64,20 @@ export default Component.extend({
   // == DOM Events ============================================================
 
   click (event) {
-    click(event, this.onSelect, this.get('item'))
+    const isRangeSelect = event.shiftKey
+    const isSpecificSelect = false
+
+    // Only process simple clicks or clicks with the acceptable modifiers
+    if (isSimpleClick(event) || isRangeSelect) {
+      event.preventDefault()
+      event.stopPropagation()
+
+      this.onSelect({
+        isRangeSelect,
+        isSpecificSelect,
+        item: this.get('item')
+      })
+    }
   },
 
   // == Lifecycle Hooks =======================================================

--- a/addon/components/frost-table.js
+++ b/addon/components/frost-table.js
@@ -125,7 +125,8 @@ export default Component.extend({
     $(document).on(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
   },
 
-  willDestroy () {
+  willDestroyElement () {
+    this._super(...arguments)
     $(document).off(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
   },
 

--- a/addon/components/frost-table.js
+++ b/addon/components/frost-table.js
@@ -1,3 +1,4 @@
+/* global $ */
 /**
  * Component definition for the frost-table component
  */
@@ -117,6 +118,16 @@ export default Component.extend({
   // == DOM Events ============================================================
 
   // == Lifecycle Hooks =======================================================
+
+  init () {
+    this._super(...arguments)
+    this._keyHandler = this.setShift.bind(this)
+    $(document).on(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
+  },
+
+  willDestroy () {
+    $(document).off(`keyup.${this.elementId} keydown.${this.elementId}`, this._keyHandler)
+  },
 
   didRender () {
     const selectable = this.get('_isSelectable')

--- a/app/styles/ember-frost-table/_frost-fixed-table.scss
+++ b/app/styles/ember-frost-table/_frost-fixed-table.scss
@@ -138,4 +138,9 @@ $frost-fixed-table-selected-cell-margin: -1px;
     flex: 1 0 auto;
     vertical-align: middle;
   }
+
+  &.shift-down {
+    // Range select doesn't select text
+    user-select: none;
+  }
 }

--- a/tests/helpers/selection.js
+++ b/tests/helpers/selection.js
@@ -1,0 +1,40 @@
+/* global $ */
+import {expect} from 'chai'
+import {$hook} from 'ember-hook'
+
+function createRangeSelectEvent () {
+  const e = $.Event('click')
+  e.shiftKey = true
+  return e
+}
+
+export function assertRowsSelected (rowHook, ...rowNumbers) {
+  const rows = $hook(rowHook)
+  let remainingRows = rows
+  for (let rowNumber of rowNumbers) {
+    const row = rows.eq(rowNumber)
+    expect(row).to.have.class('is-selected')
+    remainingRows = remainingRows.not(row)
+  }
+
+  // ensure remaining rows aren't selected
+  expect(remainingRows).to.not.have.class('is-selected')
+}
+
+export function rowBodyRangeSelect (rowHook, row1, row2) {
+  $hook(rowHook, {row: row1}).trigger(createRangeSelectEvent())
+  $hook(rowHook, {row: row2}).trigger(createRangeSelectEvent())
+}
+
+export function rowBodySingleSelect (rowHook, row) {
+  $hook(rowHook, {row}).click()
+}
+
+export function rowCheckboxRangeSelect (rowHook, row1, row2) {
+  $hook(`${rowHook}-selectionCell`, {row: row1}).trigger(createRangeSelectEvent())
+  $hook(`${rowHook}-selectionCell`, {row: row2}).trigger(createRangeSelectEvent())
+}
+
+export function rowCheckboxSingleSelect (rowHook, row) {
+  $hook(`${rowHook}-selectionCell`, {row}).click()
+}

--- a/tests/unit/components/frost-fixed-table-test.js
+++ b/tests/unit/components/frost-fixed-table-test.js
@@ -204,6 +204,26 @@ describe(test.label, function () {
         })
       })
     })
+
+    describe('_isSelectable', function () {
+      describe('selection is enabled', function () {
+        beforeEach(function () {
+          component.setProperties({
+            onSelectionChange: function () {}
+          })
+        })
+
+        it('_isSelectable should be true', function () {
+          expect(component.get('_isSelectable')).to.equal(true)
+        })
+      })
+
+      describe('selection is not enabled', function () {
+        it('_isSelectable should be false', function () {
+          expect(component.get('_isSelectable')).to.equal(false)
+        })
+      })
+    })
   })
 
   describe('.didRender()', function () {

--- a/tests/unit/components/frost-table-test.js
+++ b/tests/unit/components/frost-table-test.js
@@ -69,7 +69,7 @@ describe(test.label, function () {
       })
 
       describe('selection is not enabled', function () {
-        it('_isSelectable should be true', function () {
+        it('_isSelectable should be false', function () {
           expect(component.get('_isSelectable')).to.equal(false)
         })
       })


### PR DESCRIPTION
### This project uses [semver](semver.org), please check the scope of this pr:

- [ ] #none# - documentation fixes and/or test additions
- [X] #patch# - backwards-compatible bug fix
- [ ] #minor# - adding functionality in a backwards-compatible manner
- [ ] #major# - incompatible API change

This PR prevents text from being selected when doing a range select and when clicking on a row body (as opposed to the checkbox) that row will be the only selected one

# CHANGELOG
 * **Fixed** selection functionality to match `ember-frost-list`
